### PR TITLE
Feature/tunnel support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist/ && tsc",
+    "prepare": "npm run build",
     "release": "npm run-script build && npm publish",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/Lift.ts
+++ b/src/Lift.ts
@@ -45,6 +45,7 @@ export type Access = 'private' | null
  * @property {boolean | null} detachable - Whether the lift has detachable grips. Derived from the OpenStreetMap aerialway:detachable tag.
  * @property {boolean | null} bubble - Whether the lift has bubbles/covers to protect from weather. Derived from the OpenStreetMap aerialway:bubble tag.
  * @property {boolean | null} heating - Whether the lift has heated carriers/seats. Derived from the OpenStreetMap aerialway:heating tag.
+ * @property {boolean | null} tunnel - Whether the lift passes through a tunnel, derived from the OpenStreetMap "tunnel" tag. True for any tunnel value (e.g. "yes", "avalanche_protector", "building_passage"), null if untagged.
  * @property {LiftStationSpotFeature[]} stations - Lift station spot features associated with this lift.
  * @property {SkiAreaSummaryFeature[]} skiAreas - Ski areas this lift is a part of.
  * @property {Source[]} sources - Data sources for the feature.
@@ -69,6 +70,7 @@ export type LiftProperties = {
   detachable: boolean | null
   bubble: boolean | null
   heating: boolean | null
+  tunnel: boolean | null
   stations: LiftStationSpotFeature[]
   skiAreas: SkiAreaSummaryFeature[]
   sources: Source[]

--- a/src/Run.ts
+++ b/src/Run.ts
@@ -53,6 +53,7 @@ export type RunFeature = GeoJSON.Feature<RunGeometry, RunProperties>
  * @property {boolean | null} patrolled - Whether the run is patrolled by ski patrol, derived from the OpenStreetMap "piste:patrolled" or "patrolled" tag.
  * @property {boolean | null} snowmaking - Whether the run has its operation secured through snowmaking, derived from the OpenStreetMap "piste:snowmaking" tag.
  * @property {boolean | null} snowfarming - Whether the run has its early season operation secured through snowfarming (storing snow from previous season), derived from the OpenStreetMap "piste:snowfarming" tag.
+ * @property {boolean | null} tunnel - Whether the run passes through a tunnel, derived from the OpenStreetMap "tunnel" tag. True for any tunnel value (e.g. "yes", "avalanche_protector", "building_passage"), null if untagged.
  * @property {RunGrooming | null} grooming - Grooming status/type of the run, derived from the OpenStreetMap "piste:grooming" tag. If not specified explicitly, for difficulties "expert", "freeride", and "extreme", grooming is assumed to be "backcountry".
  * @property {SkiAreaSummaryFeature[]} skiAreas - Ski areas this run belongs to. Derived from the OpenStreetMap site=piste relation or landuse=winter_sports area and proximity to ski area features. Runs with "backcountry" grooming are not associated with ski areas unless they have a "piste:patrolled=yes" or "patrolled=yes" OpenStreetMap tag, or are part of a "site=piste" ski area relation.
  * @property {ElevationProfile | null} elevationProfile - Elevation profile of the run, only available for runs with LineString geometry.
@@ -78,6 +79,7 @@ export type RunProperties = {
   patrolled: boolean | null
   snowmaking: boolean | null
   snowfarming: boolean | null
+  tunnel: boolean | null
   grooming: RunGrooming | null
   skiAreas: SkiAreaSummaryFeature[]
   elevationProfile: ElevationProfile | null


### PR DESCRIPTION
Add tunnel property to RunProperties and LiftProperties
Adds support for the OSM tunnel tag on piste and aerialway/railway ways,
which indicates the feature passes through a tunnel rather than over a mountain.
True for any tunnel value (yes, avalanche_protector, building_passage, etc),
null if untagged.

See: https://wiki.openstreetmap.org/wiki/Key:tunnel

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>